### PR TITLE
Specify serialization methods in Content directly.

### DIFF
--- a/casper.cabal
+++ b/casper.cabal
@@ -22,11 +22,11 @@ library
   default-language: Haskell2010
   ghc-options:      -Wall
   build-depends:
-      base               >=4.7 && <5
-    , base16-bytestring
-    , base64-bytestring
+      aeson
+    , base               >=4.7     && <5
+    , base16-bytestring  >=1.0.0.0
+    , base64-bytestring  >=1.1.0.0
     , bytestring
-    , cereal
     , containers
     , cryptonite
     , directory

--- a/default.nix
+++ b/default.nix
@@ -1,15 +1,23 @@
 let
   # haskellNix = import <haskell-nix> {};
-  haskellNixSrc = builtins.fetchTarball {
+  nixpkgs = builtins.fetchTarball
+    {
+      url =
+        "https://github.com/NixOS/nixpkgs/archive/78dc359abf8217da2499a6da0fcf624b139d7ac3.tar.gz";
+      sha256 = "0wgfvkwxj8vvy100dccffb6igbqljvhgyxdk8c9gk4k2zlkygz45";
+    };
+  # haskell.nix master as of 2020-12-14
+  # Import using haskell.nix v2 format
+  haskell-nix = builtins.fetchTarball {
     url =
-      "https://github.com/input-output-hk/haskell.nix/archive/fd60cf3f07d8e3c01feed62b69ea944c5fa067e7.tar.gz";
-    sha256 = "090hmx3ppzbf2f59m9y9b8nvsrqbgrfvm1jj2630v6x72vh17wpa";
+      "https://github.com/input-output-hk/haskell.nix/archive/22de1b849a7c4137401acc81376fc722d97aafa8.tar.gz";
+    sha256 = "1qm7lki0xq5n5w4dcxxawzwkkww5lr9sv45kp2f1zh9rdc1jmf68";
   };
-  haskellNix = import haskellNixSrc { };
-  pkgsSrc = haskellNix.sources.nixpkgs-2003;
+  haskellNix = import haskell-nix { };
   pkgsArgs = haskellNix.nixpkgsArgs;
-  pkgs = import pkgsSrc pkgsArgs;
-in pkgs.haskell-nix.project {
+  pkgs = import nixpkgs pkgsArgs;
+in
+pkgs.haskell-nix.project {
   src = pkgs.haskell-nix.haskellLib.cleanGit {
     name = "casper-source";
     src = ./.;

--- a/shell.nix
+++ b/shell.nix
@@ -1,10 +1,12 @@
 let hsPkgs = import ./.;
-in hsPkgs.shellFor {
+in
+hsPkgs.shellFor {
   withHoogle = true;
   tools = {
     cabal = "3.2.0.0";
     hlint = "3.1.5";
     ghcid = "0.8.7";
+    haskell-language-server = "latest";
     ghcide = "0.2.0";
     ormolu = "0.1.0.0";
   };

--- a/src/Casper.hs
+++ b/src/Casper.hs
@@ -1,9 +1,9 @@
 module Casper
-  ( module Re,
-    CasperT,
+  ( CasperT,
     CasperError,
-    Address,
+    Ref,
     Content (..),
+    JSONContent,
     SHA256 (..),
     Store,
     store,
@@ -20,5 +20,4 @@ where
 
 import Content
 import Control.Monad.Except (catchError)
-import Data.Serialize as Re
 import Internal


### PR DESCRIPTION
By not depending on `Serialize` from `cereal` we can use JSON as the default storage format which has a slightly better story w.r.t. backwards-compatibility.