### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,18 @@
+name: "Build and test"
+on: push
+jobs:
+    build-and-test:
+        strategy:
+            matrix:
+                os:
+                    - ubuntu-latest
+                    - macos-latest
+        runs-on: ${{ matrix.os }}
+        steps:
+            - uses: actions/checkout@v3
+            - uses: cachix/install-nix-action@v17
+              with:
+                  extra_nix_config: |
+                      access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+            - run: nix build .#"casper:lib:casper"
+            - run: nix build .#"casper:test:casper-spec"


### PR DESCRIPTION
Use GitHub hosted runners to build the library and test with `casper-spec` on linux and macOS.